### PR TITLE
Create the extension function Measure to be able to avoid measure.`in`()

### DIFF
--- a/src/main/kotlin/frc/robot/lib/extensions/Measures.kt
+++ b/src/main/kotlin/frc/robot/lib/extensions/Measures.kt
@@ -210,3 +210,11 @@ val Number.kilogramSquareMeters: MomentOfInertia
 
 operator fun MomentOfInertia.get(unit: MomentOfInertiaUnit): Double =
     this.`in`(unit)
+
+/**
+ * Alternative syntax for [Measure.`in`(...)] that doesn't require tildas.
+ * Matches the format of toUnit(...) which also takes units.
+ */
+fun <U : edu.wpi.first.units.Unit> Measure<U>.InUnits(units : U) : Double{
+    return this.`in`(units)
+}


### PR DESCRIPTION
Code snippet comparison:
```kotlin
val ANGULAR_CONSTRAINTS =
    TrapezoidProfile.Constraints(
        MAX_ANGULAR_VELOCITY.`in`(RadiansPerSecond),
        MAX_ANGULAR_ACCELERATION.`in`(RadiansPerSecondPerSecond)
    )
```
becomes:
```kotlin
val ANGULAR_CONSTRAINTS =
    TrapezoidProfile.Constraints(
        MAX_ANGULAR_VELOCITY.InUnits(RadiansPerSecond),
        MAX_ANGULAR_ACCELERATION.InUnits(RadiansPerSecondPerSecond)
    )
```
We already have a function ToUnits(units : U) which also takes in units, so the naming convention feels consistent.
I also don't want to explain to people new to programming why .`in`(...) is a thing.
Lastly, I think its more clear what this operation does (converting units), and the old format is still available.